### PR TITLE
Add ability to set LOG_LEVEL with an environment variable (Cloudflare Workers)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,10 +12,13 @@ import type { LiteralString } from "./utils";
 export const pinoLogger = <ContextKey extends string = "logger">(
   opts?: Options<LiteralString<ContextKey>>,
 ): MiddlewareHandler<Env<ContextKey>> => {
-  const rootLogger = isPino(opts?.pino) ? opts.pino : pino(opts?.pino);
-  const contextKey = opts?.contextKey ?? ("logger" as ContextKey);
-
   return async (c, next) => {
+    const rootLogger = isPino(opts?.pino) ? opts.pino : pino(opts?.pino);
+    const contextKey = opts?.contextKey ?? ("logger" as ContextKey);
+
+    // use LOG_LEVEL environemnt variable if set
+    rootLogger.level = c.env.LOG_LEVEL ?? rootLogger.level;
+
     const logger = new PinoLogger(rootLogger);
     c.set(contextKey, logger);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -291,6 +291,9 @@ export type HttpLoggerOptions = {
  * ```
  */
 export type Env<LoggerKey extends string = "logger"> = {
+  Bindings: {
+    LOG_LEVEL?: string;
+  };
   Variables: {
     [key in LoggerKey]: PinoLogger;
   };


### PR DESCRIPTION
Cloudflare has no globally scoped enviroment variables es modules. Instead, they are passed into an entrypoint function.
https://community.cloudflare.com/t/how-to-access-environment-variables-from-libraries/480041/2

These variables should end up on c.env in most hono implementations though. 

This branch adds the ability to specify LOG_LEVEL as an environment variable and have it respected by the loggers produced in this package