### PR TITLE
fix: `onReqBindings` not setting logger bindings until response

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -41,6 +41,8 @@ export const pinoLogger = <ContextKey extends string = "logger">(
       },
     };
 
+    logger.assign(bindings);
+
     // requestId
     const referRequestIdKey = (opts?.http?.referRequestIdKey ??
       "requestId") as "requestId";


### PR DESCRIPTION
I have an application using your middleware configured when running on GCP with `onReqBindings` parsing an `X-Cloud-Trace-Context` header in order to include a trace id in all logs. I realized that this wasn't working without having `onReqBindings` calling `c.var.logger.assign(bindings)` before `return bindings`.

I assume this is unintended, but let me know if not!