### PR TITLE
feat: Add nodeRuntime option to enhance non-Node.js compatibility

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -130,6 +130,16 @@ export interface Options<ContextKey extends string = "logger"> {
     | ((c: Context) => pino.ChildLoggerOptions);
 
   /**
+   * Specify whether to treat as Node/Bun runtime.
+   * - true: Always treat as Node/Bun (do not use getRuntimeKey)
+   * - false: Always treat as non-Node/Bun
+   * - "auto": Auto-detect (default, will call getRuntimeKey)
+   *
+   * @default "auto"
+   */
+  nodeRuntime?: boolean | "auto";
+
+  /**
    * http request log options
    *
    * @description set to false to disable

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,9 +1,15 @@
 import { Hono } from "hono";
 import { pino } from "pino";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { PinoLogger } from "./logger";
 import { logger } from "./middleware";
-import { getLogger, isPino } from "./utils";
+import {
+  createConsoleDestinationStream,
+  getLogger,
+  isPino,
+  isPinoTransport,
+  LiteralString,
+} from "./utils";
 
 describe("isPinoLogger", () => {
   it("test pino", () => {
@@ -32,4 +38,31 @@ it("getLogger", async () => {
   const res = await app.request("/");
   expect(res.status).toBe(200);
   expect(res.text()).resolves.toBe("ok");
+});
+
+describe("createConsoleDestinationStream", () => {
+  it("should return a destination stream with write method that logs to console", () => {
+    const stream = createConsoleDestinationStream();
+    expect(typeof stream.write).toBe("function");
+    const spy = vi.spyOn(console, "log");
+    stream.write("hello world");
+    expect(spy).toHaveBeenCalledWith("hello world");
+    spy.mockRestore();
+  });
+});
+
+describe("isPinoTransport", () => {
+  it("should return true for a valid DestinationStream", () => {
+    const stream = { write: (msg: string) => {} };
+    expect(isPinoTransport(stream)).toBe(true);
+  });
+  it("should return false for invalid values", () => {
+    expect(isPinoTransport(null)).toBe(false);
+    expect(isPinoTransport(undefined)).toBe(false);
+    expect(isPinoTransport({})).toBe(false);
+    expect(isPinoTransport({ write: 123 })).toBe(false);
+    expect(isPinoTransport({ write: () => {}, foo: 1 })).toBe(true);
+    expect(isPinoTransport(123)).toBe(false);
+    expect(isPinoTransport("string")).toBe(false);
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,3 +32,25 @@ export type LiteralString<T> = T extends string
     ? never
     : T
   : never;
+
+export function isPinoTransport(
+  value: unknown,
+): value is pino.DestinationStream {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "write" in value &&
+    typeof value.write === "function"
+  );
+}
+
+/**
+ * Create a console destination stream
+ */
+export function createConsoleDestinationStream(): pino.DestinationStream {
+  return {
+    write(msg: string) {
+      console.log(msg);
+    },
+  };
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying the runtime environment (Node/Bun or others) via a new option, allowing for environment-aware logger creation.
  * Introduced automatic detection and handling of logging streams in different runtimes, including fallback to console logging where appropriate.

* **Bug Fixes**
  * Improved logger setup to better handle various runtime environments and transport options.

* **Tests**
  * Added comprehensive tests for new runtime options and utility functions related to logging streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->