### PR TITLE
Fix: remove duplicate `req` property in logs

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -41,15 +41,18 @@ export const pinoLogger = <ContextKey extends string = "logger">(
       return;
     }
 
-    let bindings = opts?.http?.onReqBindings?.(c) ?? {
-      req: {
-        url: c.req.path,
-        method: c.req.method,
-        headers: c.req.header(),
+    logger.assign(
+      opts?.http?.onReqBindings?.(c) ?? {
+        req: {
+          url: c.req.path,
+          method: c.req.method,
+          headers: c.req.header(),
+        },
       },
-    };
+    );
 
-    logger.assign(bindings);
+    // Create new set of bindings so `req` is not duplicated in logs
+    let bindings = opts?.http?.onReqBindings?.(c) ?? {};
 
     // requestId
     const referRequestIdKey = (opts?.http?.referRequestIdKey ??


### PR DESCRIPTION
The `req` property appears twice in all logs because Pino doesn't deduplicate object properties for performance reasons (https://github.com/pinojs/pino/issues/682). When both parent and child logger bindings contain the same property, both are included in the output.

This was probably overlooked in your tests because `JSON.parse` automatically deduplicates object properties:

https://github.com/maou-shonen/hono-pino/blob/8aa0a54755d7293fe8362e16af532d3c8ea8c6ec/src/middleware.test.ts#L49

This PR fixes this bug by removing `req` from parent bindings after assigning it to a child logger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how request information is assigned to the logger, reducing duplication and streamlining logging behavior. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->