### PR TITLE
fix: update pino import statements to default import syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ See all options in [src/debug-log/types.d.ts](./src/debug-log/types.d.ts)
 ### Basic Usage (Node.js)
 
 ```ts
-import { pino } from "pino";
+import pino from "pino";
 import { Hono } from "hono";
 import { pinoLogger } from "hono-pino";
 import type { DebugLogOptions } from "hono-pino/debug-log";
@@ -184,7 +184,7 @@ const app = new Hono().use(
 ### Basic Usage (Browser)
 
 ```ts
-import { pino } from "pino";
+import pino from "pino";
 import { Hono } from "hono";
 import { pinoLogger } from "hono-pino";
 import { createHandler as debugLog } from "hono-pino/debug-log";

--- a/src/debug-log/handler.ts
+++ b/src/debug-log/handler.ts
@@ -1,5 +1,5 @@
 import { getColorEnabled } from "hono/utils/color";
-import { pino } from "pino";
+import pino from "pino";
 import {
   defaultBindingsFormat,
   defaultLevelFormatter,

--- a/src/debug-log/index.test.ts
+++ b/src/debug-log/index.test.ts
@@ -1,5 +1,5 @@
 import { Transform } from "node:stream";
-import { pino } from "pino";
+import pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 import debugLogTransport from "./";
 

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,4 +1,4 @@
-import { pino } from "pino";
+import pino from "pino";
 import { beforeEach, describe, expect, it } from "vitest";
 import { httpCfgSym, PinoLogger } from "./logger";
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,5 @@
 import { defu } from "defu";
-import type { pino } from "pino";
+import type pino from "pino";
 
 /**
  * hono-pino logger instance

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,7 +1,7 @@
 import defu from "defu";
 import { Hono } from "hono";
 import { requestId } from "hono/request-id";
-import { pino } from "pino";
+import pino from "pino";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PinoLogger } from "./logger";
 import { createStaticRootLogger, pinoLogger } from "./middleware";

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import { defu } from "defu";
 import type { Context, MiddlewareHandler } from "hono";
 import { env, getRuntimeKey } from "hono/adapter";
-import { pino } from "pino";
+import pino from "pino";
 import { httpCfgSym, PinoLogger } from "./logger";
 import type { Env, Options } from "./types";
 import type { LiteralString } from "./utils";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import type { Context, Env as HonoEnv } from "hono";
 import type { IsAny } from "hono/utils/types";
-import type { pino } from "pino";
+import type pino from "pino";
 import type { PinoLogger } from "./logger";
 
 /**

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { pino } from "pino";
+import pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 import { PinoLogger } from "./logger";
 import { logger } from "./middleware";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import type { Context } from "hono";
-import type { pino } from "pino";
+import type pino from "pino";
 import type { PinoLogger } from "./logger";
 
 /**


### PR DESCRIPTION
```ts
import { pino } from 'pino'
```

The above syntax is no longer valid. pino now only exports default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Standardized logging library imports to a consistent default-import pattern across the project; no runtime behavior changes.

- Chores
  - Aligned type-only imports for the logging library to improve TypeScript compatibility and tooling interoperability.
  - Minor internal cleanups for consistent logging type references.

- Documentation
  - Updated README usage examples to reflect the new import style.

- Tests
  - Updated tests to match the standardized import pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->