### PR TITLE
docs: add security-only maintenance notice and recommend LogLayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Hono + Pino
 
+> [!WARNING]
+> This project is now in security-only maintenance mode. We strongly recommend using [LogLayer](https://github.com/theogravity/loglayer) (which includes Hono integration).
+
 [![npm version][npm-version-src]][npm-version-href]
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![JSR][jsr-version-src]][jsr-version-href]


### PR DESCRIPTION
## Summary

- Add a warning notice at the top of README indicating this project is now in security-only maintenance mode
- Recommend users to use [LogLayer](https://github.com/theogravity/loglayer) (which includes Hono integration)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to document the project's transition to security-only maintenance mode, clarifying that future updates will focus exclusively on critical security patches.
  * Added recommendation of LogLayer as an integration solution for users seeking advanced features beyond the project's maintenance scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->